### PR TITLE
Update tag and author line

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,18 +16,18 @@
   <hr>
 
   {{- if .Params.tags }}
-  <span class="post-info">
-    Tags:
+  <span class="post-info">Tags: </span>
+  <p class="post-info post-tags">
     {{- range .Params.tags }}
     <a href="/tags/{{ . | lower | urlize }}">{{ . }}</a>
     {{- end }}
-  </span>
+  </p>
   {{ end -}}
 
   {{- if .Params.author }}
-  <span class="post-info author-info">
+  <p class="post-info author-info">
     Post by {{ .Params.author }}
-  </span>
+  </p>
   {{ end -}}
 
   {{- if .Site.DisqusShortname }}

--- a/static/css/lanyon.css
+++ b/static/css/lanyon.css
@@ -332,9 +332,15 @@ a.sidebar-nav-item:focus {
 }
 
 .post-info {
+  display: inline-block;
+  vertical-align: top;
   color: #9a9a9a;
   font-size: 0.87rem;
   font-family: "PT Sans", Helvetica, Arial, sans-serif;
+}
+
+.post-tags {
+  max-width: 60%;
 }
 
 /* Remove last comma from last tag */
@@ -344,14 +350,19 @@ a.sidebar-nav-item:focus {
 
 /* author name */
 .author-info {
-    float: right;
-    padding-top: 0.2rem;
+  float: right;
+  max-width: 30%;
 }
 
 @media (max-width: 768px) {
+  .post-tags {
+    max-width: 90%;
+  }
+
   .author-info {
     display: block;
     float: none;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
Specify `max-width` for post tags and author line. This break tags to
new line when overflow occur.
